### PR TITLE
Replace a split method by a StringTokenizer clas to parse run param.

### DIFF
--- a/src/main/java/org/netbeans/modules/python/actions/PythonRun.java
+++ b/src/main/java/org/netbeans/modules/python/actions/PythonRun.java
@@ -7,6 +7,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
+import org.apache.commons.text.StringTokenizer;
+import org.apache.commons.text.matcher.StringMatcherFactory;
 import org.netbeans.api.extexecution.ExecutionService;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.python.PythonOutputLine;
@@ -57,8 +59,7 @@ public class PythonRun {
             if (owner != null) {
                 Properties prop = PythonUtility.getProperties(owner, false);
                 if (!prop.getProperty("nbproject.run.params", "").isEmpty()) {
-                    params = prop.getProperty("nbproject.run.params", "")
-                            .split(" ");
+                    params = new StringTokenizer(prop.getProperty("nbproject.run.params", ""), StringMatcherFactory.INSTANCE.spaceMatcher(), StringMatcherFactory.INSTANCE.quoteMatcher()).getTokenArray();
                 }
             }
             if (owner != null && PythonUtility.isPoetry((PythonProject) owner) && !isDebug) {


### PR DESCRIPTION
Issue #123

In current implementation for split "Run Paramteres" of project is used split method that split a String by space. I that not handle qouted parameters with spaces and split it by space that not allow to pass the text as parameter with spaces.

To handle this situation the split method are replaced by use the StringTokenizer class, that support single (`) and duble (") quote that arrond the tekst as a params.